### PR TITLE
JBIDE-22757 use BUILD_TIMESTAMP (defined in...

### DIFF
--- a/products/browsersim-standalone/pom.xml
+++ b/products/browsersim-standalone/pom.xml
@@ -314,7 +314,7 @@
 										<arg>-i</arg>
 										<arg>jbosstools-${parsedVersion.majorVersion}.${parsedVersion.minorVersion}.${parsedVersion.incrementalVersion}.${BUILD_ALIAS}-browsersim-standalone.zip*</arg>
 										<arg>-t</arg>
-										<arg>${jbosstools-build-type}/${JOB_NAME}/${BUILD_ID}-B${BUILD_NUMBER}/</arg>
+										<arg>${jbosstools-build-type}/${JOB_NAME}/${BUILD_TIMESTAMP}-B${BUILD_NUMBER}/</arg>
 									</arguments>
 								</configuration>
 							</execution>


### PR DESCRIPTION
JBIDE-22757 use BUILD_TIMESTAMP (defined in parent pom) instead of BUILD_ID, which is now the same as BUILD_NUMBER in Jenkins